### PR TITLE
fixing the following message

### DIFF
--- a/Statistics/Measure-Object.ps1
+++ b/Statistics/Measure-Object.ps1
@@ -59,7 +59,7 @@
 
         #region Calculate standard deviation
         $StandardDeviation = [math]::Sqrt($Stats.Variance)
-        Add-Member -InputObject $Stats -MemberType NoteProperty -Name 'StandardDeviation' -Value $StandardDeviation
+        Add-Member -InputObject $Stats -MemberType NoteProperty -Name 'StandardDeviation' -Value $StandardDeviation -Force
         #endregion
 
         #region Calculate percentiles


### PR DESCRIPTION
Add-Member: /root/.local/share/powershell/Modules/Statistics/1.2.0.149/Measure-Object.ps1:62
Line |
  62 |          Add-Member -InputObject $Stats -MemberType NoteProperty -Name …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot add a member with the name "StandardDeviation" because a member with that
     | name already exists. To overwrite the member anyway, add the Force parameter to
     | your command.